### PR TITLE
Add offline scope to OIDC client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Update the following configuration variables in the `appsettings.json` file wit
         "ClientId": "{your-client-id}",
         "ClientSecret": "{your-client-secret}",
         "Issuer": "{your-authgear-app-endpoint}",
-        "Scope": "openid",
+        "Scope": "openid offline_access",
         "PostLogoutRedirectUri": "http://localhost:5002",
         "TokenEndpoint": "{your-authgear-app-endpoint}/oauth2/token"
     },

--- a/Startup.cs
+++ b/Startup.cs
@@ -26,9 +26,63 @@ namespace OidcClientDemoApplication
             Configuration = config;
         }
 
+        private void CheckSameSite(HttpContext httpContext, CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None)
+            {
+                var userAgent = httpContext.Request.Headers["User-Agent"].ToString();
+
+                if (DisallowsSameSiteNone(userAgent))
+                {
+                    options.SameSite = SameSiteMode.Unspecified;
+                }
+            }
+        }
+
+        public static bool DisallowsSameSiteNone(string userAgent)
+        {
+            if (string.IsNullOrEmpty(userAgent))
+            {
+                return false;
+            }
+
+            // Cover all iOS based browsers here. This includes:
+            // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+            // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+            // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+            // All of which are broken by SameSite=None, because they use the iOS networking stack
+            if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+            {
+                return true;
+            }
+
+            // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+            // - Safari on Mac OS X.
+            // This does not include:
+            // - Chrome on Mac OS X
+            // Because they do not use the Mac OS networking stack.
+            if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+                userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+            {
+                return true;
+            }
+
+            // Cover Chrome 50-69, because some versions are broken by SameSite=None, 
+            // and none in this range require it.
+            // Note: this covers some pre-Chromium Edge versions, 
+            // but pre-Chromium Edge does not require SameSite=None.
+            if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.UseCookiePolicy(); // Before UseAuthentication or anything else that writes cookies.
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
@@ -43,22 +97,21 @@ namespace OidcClientDemoApplication
             // Prevent WS-Federation claim names being written to tokens
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+            });
+
             services.AddAuthentication(options =>
             {
                 options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
             })
-            .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
-            {
-                // Use the strongest setting in production, which also enables HTTP on developer workstations
-                options.Cookie.SameSite = SameSiteMode.Strict;
-            })
+            .AddCookie()
             .AddOpenIdConnect(options =>
             {
-
-                // Use the same settings for temporary cookies
-                options.NonceCookie.SameSite = SameSiteMode.Strict;
-                options.CorrelationCookie.SameSite = SameSiteMode.Strict;
 
                 // Set the main OpenID Connect settings
                 options.Authority = Configuration.GetValue<string>("OpenIdConnect:Issuer");

--- a/appsettings.json
+++ b/appsettings.json
@@ -3,7 +3,7 @@
         "ClientId": "{your-client-id}",
         "ClientSecret": "{your-client-secret}",
         "Issuer": "{your-authgear-app-endpoint}",
-        "Scope": "openid",
+        "Scope": "openid offline_access",
         "PostLogoutRedirectUri": "http://localhost:5002",
         "TokenEndpoint": "{your-authgear-app-endpoint}/oauth2/token"
     },


### PR DESCRIPTION
Since the tutorial for this example app includes using a refresh token, I've added the `offline_access`.